### PR TITLE
Possible fix for get_class dictionary error

### DIFF
--- a/umt/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/labelmap.txt
+++ b/umt/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29/labelmap.txt
@@ -1,7 +1,7 @@
 empty
 person
-bicycle
 car
+bicycle
 motorcycle
 airplane
 bus


### PR DESCRIPTION
Simply changing the labelmap and using labelmap.txt as the same labelmap for ped-net solves the issue.